### PR TITLE
Feat/add average basket chart admin panel

### DIFF
--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cyna-website",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cyna-website",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/pg-adapter": "^1.9.1",

--- a/App/package.json
+++ b/App/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyna-website",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/App/src/app/admin/page.tsx
+++ b/App/src/app/admin/page.tsx
@@ -20,6 +20,7 @@ import {
   Activity
 } from 'lucide-react'
 import AdminSalesChart from '@/components/admin/AdminSalesChart'
+import AdminAverageBasketChart from '@/components/admin/AdminAverageBasketChart'
 
 /**
  * Interface pour les statistiques du dashboard
@@ -277,8 +278,9 @@ export default function AdminDashboard() {
         )}
 
         {/* Graphiques */}
-        <div className="grid grid-cols-1 gap-6 mb-8">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
           <AdminSalesChart />
+          <AdminAverageBasketChart />
         </div>
 
         {/* Actions rapides */}

--- a/App/src/app/api/admin/orders/avg-basket/route.ts
+++ b/App/src/app/api/admin/orders/avg-basket/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
+
+function parseDate(input?: string | null) {
+  if (!input) return null
+  const d = new Date(input)
+  return isNaN(d.getTime()) ? null : d
+}
+
+function toISODate(d: Date) {
+  const y = d.getUTCFullYear()
+  const m = String(d.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(d.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
+function fillDateRange(from: Date, to: Date) {
+  const days: string[] = []
+  const cur = new Date(Date.UTC(from.getUTCFullYear(), from.getUTCMonth(), from.getUTCDate()))
+  const end = new Date(Date.UTC(to.getUTCFullYear(), to.getUTCMonth(), to.getUTCDate()))
+  while (cur <= end) {
+    days.push(toISODate(cur))
+    cur.setUTCDate(cur.getUTCDate() + 1)
+  }
+  return days
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user || !['ADMIN', 'SUPER_ADMIN'].includes((session.user.role as string) || '')) {
+      return NextResponse.json({ success: false, message: 'Accès non autorisé' }, { status: 403 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status') || 'succeeded'
+    const toParam = parseDate(searchParams.get('to'))
+    const fromParam = parseDate(searchParams.get('from'))
+
+    const to = toParam ?? new Date()
+    const from = fromParam ?? new Date(Date.now() - 29 * 24 * 60 * 60 * 1000) // 30 derniers jours
+
+    // SQLite aggregation: daily count, sum, avg
+    const rows: { day: string; count: number; amount: number | null; avgAmount: number | null }[] = await prisma.$queryRawUnsafe(
+      `SELECT date(createdAt) AS day,
+              COUNT(*) AS count,
+              SUM(amount) AS amount,
+              AVG(amount) AS avgAmount
+       FROM orders
+       WHERE status = ? AND datetime(createdAt) BETWEEN datetime(?) AND datetime(?)
+       GROUP BY date(createdAt)
+       ORDER BY date(createdAt) ASC`,
+      status,
+      from.toISOString(),
+      to.toISOString()
+    )
+
+    const byDay = new Map<string, { count: number; amount: number; avgAmount: number }>()
+    for (const r of rows) {
+      byDay.set(r.day, {
+        count: Number(r.count || 0),
+        amount: Number(r.amount || 0),
+        avgAmount: Math.round(Number(r.avgAmount || 0)), // en centimes, arrondi
+      })
+    }
+
+    const days = fillDateRange(from, to)
+    const points = days.map((day) => ({
+      day,
+      count: byDay.get(day)?.count ?? 0,
+      amount: byDay.get(day)?.amount ?? 0,
+      avgAmount: byDay.get(day)?.avgAmount ?? 0,
+    }))
+
+    const totals = points.reduce(
+      (acc, p) => {
+        acc.count += p.count
+        acc.amount += p.amount
+        return acc
+      },
+      { count: 0, amount: 0 }
+    )
+
+    const avgAmountOverall = totals.count > 0 ? Math.round(totals.amount / totals.count) : 0
+
+    return NextResponse.json({
+      success: true,
+      range: { from: from.toISOString(), to: to.toISOString() },
+      currency: 'EUR',
+      points,
+      totals: { ...totals, avgAmountOverall },
+    })
+  } catch (error) {
+    console.error('Erreur avg-basket:', error)
+    return NextResponse.json({ success: false, message: 'Erreur serveur' }, { status: 500 })
+  }
+}

--- a/App/src/components/admin/AdminAverageBasketChart.tsx
+++ b/App/src/components/admin/AdminAverageBasketChart.tsx
@@ -1,0 +1,118 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts'
+
+type Point = { day: string; count: number; amount: number; avgAmount: number }
+
+function formatDateLabel(isoDay: string) {
+  const [y, m, d] = isoDay.split('-').map(Number)
+  const date = new Date(Date.UTC(y, (m || 1) - 1, d || 1))
+  return date.toLocaleDateString('fr-FR', { day: '2-digit', month: '2-digit' })
+}
+
+function formatEur(cents: number) {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(cents / 100)
+}
+
+export default function AdminAverageBasketChart() {
+  const [range, setRange] = useState<'7' | '30' | '90'>('30')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [data, setData] = useState<Point[]>([])
+  const [totals, setTotals] = useState<{ amount: number; count: number; avgAmountOverall: number }>({ amount: 0, count: 0, avgAmountOverall: 0 })
+
+  const { from, to } = useMemo(() => {
+    const to = new Date()
+    const days = range === '7' ? 6 : range === '30' ? 29 : 89
+    const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    return { from, to }
+  }, [range])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const url = `/api/admin/orders/avg-basket?from=${from.toISOString()}&to=${to.toISOString()}&status=succeeded`
+        const res = await fetch(url)
+        const json = await res.json()
+        if (!res.ok || !json.success) throw new Error(json.message || 'Erreur chargement panier moyen')
+        setData(json.points as Point[])
+        setTotals(json.totals)
+      } catch (e: any) {
+        setError(e?.message || 'Erreur inconnue')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [from, to])
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium text-gray-900">Panier moyen par jour</h2>
+        <div className="flex gap-2">
+          {(['7','30','90'] as const).map((val) => (
+            <button
+              key={val}
+              onClick={() => setRange(val)}
+              className={`px-3 py-1.5 text-sm rounded-md border ${range === val ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'}`}
+            >
+              {val} j
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-red-700 bg-red-50 border border-red-200 rounded p-3 mb-4">{error}</div>
+      )}
+
+      {loading ? (
+        <div className="h-64 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+        </div>
+      ) : data.length === 0 ? (
+        <div className="h-64 flex flex-col items-center justify-center text-gray-500">
+          <p>Aucune donnée</p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-4 mb-4">
+            <div>
+              <div className="text-xs text-gray-500">Panier moyen global</div>
+              <div className="text-lg font-semibold">{formatEur(totals.avgAmountOverall)}</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500">Revenus</div>
+              <div className="text-lg font-semibold">{formatEur(totals.amount)}</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500">Commandes</div>
+              <div className="text-lg font-semibold">{totals.count}</div>
+            </div>
+          </div>
+
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={data} margin={{ top: 4, right: 16, bottom: 0, left: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} />
+                <XAxis dataKey="day" tickFormatter={formatDateLabel} tick={{ fontSize: 12 }} />
+                <YAxis tickFormatter={(v) => formatEur(v)} tick={{ fontSize: 12 }} width={70} />
+                <Tooltip
+                  formatter={(value: any, name: string) =>
+                    name === 'avgAmount' ? [formatEur(value as number), 'Panier moyen'] : [String(value), name === 'count' ? 'Commandes' : 'Revenus']
+                  }
+                  labelFormatter={(label) => new Date(label).toLocaleDateString('fr-FR')}
+                />
+                <Bar dataKey="avgAmount" name="Panier moyen" fill="#10b981" radius={[4, 4, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
### Description
Add two lightweight analytics widgets to the admin dashboard: daily sales (revenue) and daily average order value (AOV). No database schema changes; reuses existing `orders` data.

### Changes Made
- API endpoints
  - `GET /api/admin/orders/stats`: aggregates revenue and order count per day
  - `GET /api/admin/orders/avg-basket`: computes daily AOV (average basket)
- UI components
  - `App/src/components/admin/AdminSalesChart.tsx`: daily revenue bar chart with 7/30/90‑day range
  - `App/src/components/admin/AdminAverageBasketChart.tsx`: daily AOV bar chart with 7/30/90‑day range
- Admin integration
  - Both charts rendered under the main stats in `App/src/app/admin/page.tsx`
- Dependency
  - Added `recharts`

### Technical Details
- SQLite aggregation using `date(createdAt)`; filters by `status` (default `succeeded`) and date range (`from`, `to`)
- API responses include continuous days; gaps are filled with zeros on the server
- Totals returned; AOV overall = total amount / total count (cents)
- Charts built with Recharts; EUR formatting on axes/tooltips; responsive containers
- Grouping in UTC for consistency; can switch to local time later if needed

### Benefits
- Immediate visibility on revenue trends and AOV without introducing migrations or BI tooling
- Simple controls (7/30/90 days), fast to load, minimal scope
- Extensible foundation for future filters (status, services) or monthly grouping

### How to Test
1. From `App/`: run `npm i` then `npm run dev`
2. Log in as `ADMIN`/`SUPER_ADMIN`, open `/admin`
3. In “Ventes par jour” and “Panier moyen par jour”:
   - Toggle 7/30/90 days and verify the charts refresh
   - Check tooltips, totals, and that missing days appear with zero values
   - Validate EUR formatting and that AOV = revenue / count for a given day