### PR TITLE
Feat/add catagory sales pie chart admin panel

### DIFF
--- a/App/package-lock.json
+++ b/App/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cyna-website",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cyna-website",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
         "@auth/pg-adapter": "^1.9.1",

--- a/App/package.json
+++ b/App/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cyna-website",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/App/src/app/admin/page.tsx
+++ b/App/src/app/admin/page.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lucide-react'
 import AdminSalesChart from '@/components/admin/AdminSalesChart'
 import AdminAverageBasketChart from '@/components/admin/AdminAverageBasketChart'
+import AdminCategorySalesPie from '@/components/admin/AdminCategorySalesPie'
 
 /**
  * Interface pour les statistiques du dashboard
@@ -278,9 +279,10 @@ export default function AdminDashboard() {
         )}
 
         {/* Graphiques */}
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
+        <div className="grid grid-cols-1 xl:grid-cols-3 gap-6 mb-8">
           <AdminSalesChart />
           <AdminAverageBasketChart />
+          <AdminCategorySalesPie />
         </div>
 
         {/* Actions rapides */}

--- a/App/src/app/api/admin/orders/by-category/route.ts
+++ b/App/src/app/api/admin/orders/by-category/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { prisma } from '@/lib/prisma'
+import { auth } from '@/auth'
+
+function parseDate(input?: string | null) {
+  if (!input) return null
+  const d = new Date(input)
+  return isNaN(d.getTime()) ? null : d
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const session = await auth()
+    if (!session?.user || !['ADMIN', 'SUPER_ADMIN'].includes((session.user.role as string) || '')) {
+      return NextResponse.json({ success: false, message: 'Accès non autorisé' }, { status: 403 })
+    }
+
+    const { searchParams } = new URL(request.url)
+    const status = searchParams.get('status') || 'succeeded'
+    const toParam = parseDate(searchParams.get('to'))
+    const fromParam = parseDate(searchParams.get('from'))
+    const minPercentParam = Number(searchParams.get('minPercent') || '0.03') // 3% par défaut
+
+    const to = toParam ?? new Date()
+    const from = fromParam ?? new Date(Date.now() - 29 * 24 * 60 * 60 * 1000)
+
+    // Agrégation SQLite par metadata.category
+    const rows: { category: string | null; count: number; amount: number | null }[] = await prisma.$queryRawUnsafe(
+      `SELECT COALESCE(json_extract(metadata, '$.category'), 'Unknown') AS category,
+              COUNT(*) AS count,
+              SUM(amount) AS amount
+       FROM orders
+       WHERE status = ? AND datetime(createdAt) BETWEEN datetime(?) AND datetime(?)
+       GROUP BY COALESCE(json_extract(metadata, '$.category'), 'Unknown')
+       ORDER BY amount DESC`,
+      status,
+      from.toISOString(),
+      to.toISOString()
+    )
+
+    const items = rows.map((r) => ({
+      category: (r.category ?? 'Unknown') as string,
+      count: Number(r.count || 0),
+      amount: Number(r.amount || 0),
+    }))
+
+    const totals = items.reduce(
+      (acc, it) => {
+        acc.count += it.count
+        acc.amount += it.amount
+        return acc
+      },
+      { count: 0, amount: 0 }
+    )
+
+    // Calcul des pourcentages et regroupement des petites parts
+    const withPercent = items.map((it) => ({
+      ...it,
+      percent: totals.amount > 0 ? it.amount / totals.amount : 0,
+    }))
+
+    // Regrouper en "Other" les catégories sous le seuil
+    const small = withPercent.filter((it) => it.percent < minPercentParam)
+    const large = withPercent.filter((it) => it.percent >= minPercentParam)
+
+    const other = small.reduce(
+      (acc, it) => {
+        acc.count += it.count
+        acc.amount += it.amount
+        return acc
+      },
+      { category: 'Other', count: 0, amount: 0, percent: 0 }
+    )
+
+    const finalItems = [...large, ...(other.amount > 0 ? [
+      { ...other, percent: totals.amount > 0 ? other.amount / totals.amount : 0 },
+    ] : [])]
+      .sort((a, b) => b.amount - a.amount)
+
+    return NextResponse.json({
+      success: true,
+      range: { from: from.toISOString(), to: to.toISOString() },
+      currency: 'EUR',
+      items: finalItems,
+      totals,
+    })
+  } catch (error) {
+    console.error('Erreur by-category:', error)
+    return NextResponse.json({ success: false, message: 'Erreur serveur' }, { status: 500 })
+  }
+}

--- a/App/src/components/admin/AdminAverageBasketChart.tsx
+++ b/App/src/components/admin/AdminAverageBasketChart.tsx
@@ -52,7 +52,7 @@ export default function AdminAverageBasketChart() {
   return (
     <div className="bg-white rounded-lg shadow-md p-6">
       <div className="flex items-center justify-between mb-4">
-        <h2 className="text-lg font-medium text-gray-900">Panier moyen par jour</h2>
+        <h2 className="text-lg font-medium text-gray-900">Panier moyen jour</h2>
         <div className="flex gap-2">
           {(['7','30','90'] as const).map((val) => (
             <button

--- a/App/src/components/admin/AdminCategorySalesPie.tsx
+++ b/App/src/components/admin/AdminCategorySalesPie.tsx
@@ -110,7 +110,7 @@ export default function AdminCategorySalesPie() {
                   ))}
                 </Pie>
                 <Tooltip
-                  formatter={(value: any, name: string, p: any) => [formatEur(value as number), name]}
+                  formatter={(value: any, name: string) => [formatEur(value as number), name]}
                   labelFormatter={() => ''}
                 />
                 <Legend verticalAlign="bottom" height={24} />

--- a/App/src/components/admin/AdminCategorySalesPie.tsx
+++ b/App/src/components/admin/AdminCategorySalesPie.tsx
@@ -1,0 +1,124 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import { ResponsiveContainer, PieChart, Pie, Tooltip, Cell, Legend } from 'recharts'
+
+interface Item { category: string; count: number; amount: number; percent: number }
+
+function formatEur(cents: number) {
+  return new Intl.NumberFormat('fr-FR', { style: 'currency', currency: 'EUR' }).format(cents / 100)
+}
+
+const COLORS = [
+  '#6366f1', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#84cc16', '#f97316', '#dc2626', '#22c55e'
+]
+
+function colorForIndex(i: number) {
+  return COLORS[i % COLORS.length]
+}
+
+export default function AdminCategorySalesPie() {
+  const [range, setRange] = useState<'7' | '30' | '90'>('30')
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [items, setItems] = useState<Item[]>([])
+  const [totals, setTotals] = useState<{ amount: number; count: number }>({ amount: 0, count: 0 })
+
+  const { from, to } = useMemo(() => {
+    const to = new Date()
+    const days = range === '7' ? 6 : range === '30' ? 29 : 89
+    const from = new Date(Date.now() - days * 24 * 60 * 60 * 1000)
+    return { from, to }
+  }, [range])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        setLoading(true)
+        setError(null)
+        const url = `/api/admin/orders/by-category?from=${from.toISOString()}&to=${to.toISOString()}&status=succeeded&minPercent=0.03`
+        const res = await fetch(url)
+        const json = await res.json()
+        if (!res.ok || !json.success) throw new Error(json.message || 'Erreur chargement catégories')
+        setItems(json.items as Item[])
+        setTotals(json.totals)
+      } catch (e: any) {
+        setError(e?.message || 'Erreur inconnue')
+      } finally {
+        setLoading(false)
+      }
+    }
+    fetchData()
+  }, [from, to])
+
+  return (
+    <div className="bg-white rounded-lg shadow-md p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-medium text-gray-900">Ventes par catégorie</h2>
+        <div className="flex gap-2">
+          {(['7','30','90'] as const).map((val) => (
+            <button
+              key={val}
+              onClick={() => setRange(val)}
+              className={`px-3 py-1.5 text-sm rounded-md border ${range === val ? 'bg-indigo-600 text-white border-indigo-600' : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50'}`}
+            >
+              {val} j
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {error && (
+        <div className="text-red-700 bg-red-50 border border-red-200 rounded p-3 mb-4">{error}</div>
+      )}
+
+      {loading ? (
+        <div className="h-64 flex items-center justify-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600" />
+        </div>
+      ) : items.length === 0 ? (
+        <div className="h-64 flex flex-col items-center justify-center text-gray-500">
+          <p>Aucune donnée</p>
+        </div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-4 mb-4">
+            <div>
+              <div className="text-xs text-gray-500">Revenus</div>
+              <div className="text-lg font-semibold">{formatEur(totals.amount)}</div>
+            </div>
+            <div>
+              <div className="text-xs text-gray-500">Commandes</div>
+              <div className="text-lg font-semibold">{totals.count}</div>
+            </div>
+          </div>
+
+          <div className="h-64">
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie
+                  data={items.map((it) => ({ name: it.category, value: it.amount, percent: it.percent, count: it.count }))}
+                  dataKey="value"
+                  nameKey="name"
+                  innerRadius={60}
+                  outerRadius={90}
+                  paddingAngle={2}
+                  label={(entry: any) => (entry.percent >= 0.05 ? `${Math.round(entry.percent * 100)}%` : '')}
+                >
+                  {items.map((_, i) => (
+                    <Cell key={`cell-${i}`} fill={colorForIndex(i)} />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value: any, name: string, p: any) => [formatEur(value as number), name]}
+                  labelFormatter={() => ''}
+                />
+                <Legend verticalAlign="bottom" height={24} />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
### Title
Admin dashboard: add sales by category pie chart

### Description
Introduce a new analytics widget showing revenue distribution by category over a selectable range (7/30/90 days). This helps admins quickly understand the sales mix by category. No database schema changes.

### Changes Made
- API: `GET /api/admin/orders/by-category`
  - Aggregates revenue and order count per category within a date range (`from`, `to`) and `status` (default `succeeded`)
  - Optionally groups small slices into "Other" via `minPercent` (default 3%)
- UI: `App/src/components/admin/AdminCategorySalesPie.tsx`
  - Recharts PieChart with legend, EUR tooltips, and range selectors (7/30/90 days)
- Admin integration: `App/src/app/admin/page.tsx`
  - Adds the "Ventes par catégorie" card alongside existing charts in the analytics grid

### Technical Details
- SQLite aggregation using `COALESCE(json_extract(metadata, '$.category'), 'Unknown')` for category lookup
- API returns: `items[{ category, amount, count, percent }]`, `totals`, and the selected `range`
- Frontend displays revenue per category; labels show percentages only for larger slices (>= 5%)
- Grouping and filtering are done in UTC for consistency with existing analytics

### Benefits
- Clear view of sales mix by category at a glance
- Minimal scope: no migrations; reuses existing `orders` data and Recharts
- Scales visually by collapsing very small categories into "Other"

### How to Test
1. From `App/`: run `npm i` (if needed) then `npm run dev`
2. Log in as `ADMIN`/`SUPER_ADMIN` and open `/admin`
3. In "Ventes par catégorie":
   - Toggle 7/30/90 days and verify the chart refreshes
   - Check tooltip amounts (EUR), legend, and that small categories are grouped as "Other" (when applicable)
   - Validate that totals (revenue/orders) in the card header match the current range